### PR TITLE
Multi update, read desc.

### DIFF
--- a/client/client.lua
+++ b/client/client.lua
@@ -8,12 +8,6 @@ TriggerEvent("menuapi:getData",function(call)
 end)
 
 Citizen.CreateThread(function()
-	Wait(1000)
-	--Wait(10000)
-	local pedModel = GetHashKey("S_M_M_Tailor_01")
-	LoadModel(pedModel)
-	BlipManager(true)	-- Initialize Store Objects/Blips
-	
 	while true do
 		local delayThread, playerPed = 500, PlayerPedId()
 		if initComplete and not inShop then
@@ -74,6 +68,13 @@ Citizen.CreateThread(function()
 	end
 end)
 
+RegisterNetEvent("vorp:SelectedCharacter")
+AddEventHandler("vorp:SelectedCharacter", function()
+	local pedModel = GetHashKey("S_M_M_Tailor_01")
+	LoadModel(pedModel)
+	Wait(1000)
+	BlipManager(true)
+end)
 
 RegisterNetEvent('vorpclothingstore:LoadYourCloths')
 AddEventHandler('vorpclothingstore:LoadYourCloths', function(comps, skin)
@@ -98,3 +99,12 @@ AddEventHandler('onResourceStop', function(resourceName)
 		Citizen.Wait(1500)
 	end
 end)
+
+if Config.debugMode then -- Only called during debugMode being on, this is so we skip vorp:SelectedCharacter
+	Citizen.CreateThread(function()
+		Citizen.Wait(1000)
+		local pedModel = GetHashKey("S_M_M_Tailor_01")
+		LoadModel(pedModel)
+		BlipManager(true)
+	end)
+end

--- a/config.lua
+++ b/config.lua
@@ -1,5 +1,6 @@
 Config = {
   defaultlang = "En", -- Set your language, verify that it exists in vorp_clothingstore/languages/
+  debugMode = false,   -- LEAVE SET TO FALSE
 
   Cost = {	-- Category Prices (Each item equiped adds to the total cost)
 	  Hats = 4.0,

--- a/languages/en.lua
+++ b/languages/en.lua
@@ -25,6 +25,11 @@ Locales["En"] = {
 
     PlaceHolderNewOutfit = "Enter Name to Save",
     ButtonNewOutfit = "Save",
+
+    PlaceHolderSpecifyComp = "Enter #0-",			-- Disregard, for upcoming update
+    ButtonSpecifyComp = "Goto",						-- Disregard, for upcoming update
+	WrongInputType = "Only numbers are allowed",	-- Disregard, for upcoming update
+	OutOfRange = "Value is out of range, max: ",	-- Disregard, for upcoming update
 	
     Finish = "Complete Purchase",
 	SelectOutfit = "Confirm Outfit Selection",

--- a/server/server.lua
+++ b/server/server.lua
@@ -90,3 +90,9 @@ AddEventHandler('vorpclothingstore:deleteOutfit', function(outfitId)
 		print("Error: SteamID not found for " .. _source)
 	end
 end)
+
+
+-- Ignore, only to warn devs when debugMode is on
+if Config.debugMode then
+	print("^3VORP_ClothingStore - Warning: ^7Debug mode is turned on, you may experience issues")
+end


### PR DESCRIPTION
- Debug mode: Dev QoL feature only
- Wait to load blips/peds until selected char
- Disable Radar/Hud inside shop
- EN lang for future update
-  If player is wearing clothing category, automatically set the menu value to that value
- Whole bunch of clever looping to make rollover of elements work (0 < sets to max # / max # > sets to 0)

**Todo:** _Suggestion for pressing "Enter" to directly input clothing #. The issue with this is I can't find a solution ATM to detect the keypress and hold the menu from trying to make changes immediately. Most likely have to do some tricky things unless menuapi has input feature added._