### PR TITLE
Fixed missing key for hair accessories

### DIFF
--- a/shared/clothesUtils.lua
+++ b/shared/clothesUtils.lua
@@ -12126,6 +12126,7 @@ CategoryHashes = {
 	Satchels = 0x94504D26,
 	GunbeltAccs = 0xF1542D11,
 	Masks = 0x7505EF42,
+	HairAccessories = 0x8E84A2AA,
 }
 
 CategoryDBName = {
@@ -12160,6 +12161,7 @@ CategoryDBName = {
 	Satchels = 0x94504D26,
 	GunbeltAccs = 0xF1542D11,
 	Mask = 0x7505EF42,
+	HairAccessories = 0x8E84A2AA,
 }
 
 CategoryClothesPlayer = {
@@ -12194,6 +12196,7 @@ CategoryClothesPlayer = {
 	Satchels = "Satchels",
 	GunbeltAccs = "GunbeltAccs",
 	Masks = "Mask",
+	HairAccessories = "bow",
 }
 
 CategoryRawNames = {
@@ -12257,5 +12260,7 @@ CategoryRawNames = {
 	GUNBELTACCS_MALE = "GunbeltAccs",
 	GUNBELTACCS_FEMALE = "GunbeltAccs",
 	MASK_MALE = "Masks",
-	MASK_FEMALE = "Masks"
+	MASK_FEMALE = "Masks",
+	HAIRACCESSORIES_FEMALE = "HairAccessories",
+    	HAIRACCESSORIES_MALE = "HairAccessories",
 }


### PR DESCRIPTION
Added multiple lines to implement compatibility with hair accessories for male and female characters. The fix solved the problem that the name of the modified accessory wasn't showing correctly and that the accessory couldn't be changed ( https://cdn.discordapp.com/attachments/1094572389884510259/1097896232770347028/image.png ). 

I explained everything even further in #vorp-support-scripts on the discord server (https://discord.com/channels/704317931453939803/1013487110407331950/1098281466938536068).