### PR TITLE
Update fxmanifest.lua

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -20,7 +20,6 @@ server_scripts {
 shared_scripts {
     'config.lua',
     'shared/*.lua',
-    'languages/*.lua',
 }
 
 files {


### PR DESCRIPTION
remove reference to non-existing "languages" folder

I had this message when starting fxserver : 
_c-scripting-core] Creating script environments for vorp_clothingstores
[resources:vorp_cloth] Warning: could not find shared_script `languages/*.lua` (defined in fxmanifest.lua:20)
[           resources] Started resource vorp_clothingstores (1 warning)_